### PR TITLE
Minor changes to improve the usability of sprunge

### DIFF
--- a/sprunge.py
+++ b/sprunge.py
@@ -31,7 +31,7 @@ class Index(webapp.RequestHandler):
 sprunge(1)                          SPRUNGE                          sprunge(1)
 
 NAME
-    sprunge: command line pastebin:
+    sprunge: command line pastebin.
 
 SYNOPSIS
     &lt;command&gt; | curl -F '%s=&lt;-' %s

--- a/sprunge.py
+++ b/sprunge.py
@@ -98,7 +98,7 @@ SEE ALSO
                                           HtmlFormatter(full=True,
                                           style='borland',
                                           lineanchors='n',
-                                          linenos='inline',
+                                          linenos='table',
                                           encoding='utf-8')))
 
     def post(self, got):

--- a/sprunge.py
+++ b/sprunge.py
@@ -24,6 +24,7 @@ class Index(webapp.RequestHandler):
     r = 'sprunge'
 
     def help(self, u, r):
+        f = 'data:text/html,<form action="%s" method="POST"><textarea name="%s" cols="80" rows="24"></textarea><br><button type="submit">%s</button></form>' % (u, r, r)
         return """
 <style> a { text-decoration: none } </style>
 <pre>
@@ -37,6 +38,7 @@ SYNOPSIS
 
 DESCRIPTION
     add <a href='http://pygments.org/docs/lexers/'>?&lt;lang&gt;</a> to resulting url for line numbers and syntax highlighting
+    use <a href='%s'>this form</a> to paste from a browser
 
 EXAMPLES
     ~$ cat bin/ching | curl -F '%s=&lt;-' %s
@@ -46,7 +48,7 @@ EXAMPLES
 SEE ALSO
     http://github.com/rupa/sprunge
 
-</pre>""" % (r, u, r, u, u, u)
+</pre>""" % (r, u, f, r, u, u, u)
 
     def new_id(self):
         nid = ''


### PR DESCRIPTION
This request includes three commits, each with a minor change.

The first, and arguably most important, is to use "table" line-numbering mode from Pygments. This allows the user to select the pasted code without highlighting unwanted line numbers along with it.

The second adds a link to the following data URI to the description section.  
`data:text/html,<title>sprunge</title><form action="http://sprunge.us" method="POST"><textarea name="sprunge" cols="80" rows="24"></textarea><br><button type="submit">sprunge</button></form>`  
This allows the user to submit a paste to sprunge from the browser. While this may be counter to sprunge's purpose as a command-line highlighter, it may be useful in some situations.

The third is a minor punctuation fix, which I changed because it was bugging me. ;)

Thanks for making and hosting sprunge It's hugely popular in the Arch Linux IRC channel.
